### PR TITLE
Add Github Action to clean-up containers in the Github Container Registry

### DIFF
--- a/.github/workflows/ghcr-cleaner.yml
+++ b/.github/workflows/ghcr-cleaner.yml
@@ -1,0 +1,26 @@
+name: Github Container Registry Cleaner
+on:
+  schedule:
+    - cron: "0 4 * * Sun"
+
+jobs:
+  delete_old_images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete untagged images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete older tagged images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          tags: main, latest, v*.*.*
+          keep-n-tagged: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete tagged images for pull requests
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          tags: pr*
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ghcr-cleaner.yml
+++ b/.github/workflows/ghcr-cleaner.yml
@@ -12,15 +12,16 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Delete older tagged images
+      - name: 'Clean up development images'
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          tags: main, latest, v*.*.*
-          keep-n-tagged: 1
+          keep-n-tagged: 10
+          exclude-tags: '*release*,*main*,*latest*'
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Delete tagged images for pull requests
+      - name: 'Clean up images from main'
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          tags: pr*
+          keep-n-tagged: 5
+          tags: '*main*'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

We make use of a [custom github action](https://github.com/dataaxiom/ghcr-cleanup-action) to clean-up untagged and older tagged containers in the Github Container Registry every sunday. This custom action allows for the deletion of repositories even though they are build by the same parent tag but have a multi-platform build. 

Resolves https://github.com/orgs/MinBZK/projects/7/views/3?pane=issue&itemId=63104096

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
